### PR TITLE
updated docs to reflect current status of server key length

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,13 @@ Do you want every corrupt government contractor to have access to your browser h
 #### Future
 
 1. Use ansible vault to encrypt group_vars/all
-2. Make a workflow for adding a new user and client certificate "for a friend"
-3. Add an automatic updates tool. 
-4. Move Stouts.openvpn default to 2048 bit certificate.
-    - [People are probably breaking 1024 keys](https://www.eff.org/deeplinks/2015/10/how-to-protect-yourself-from-nsa-attacks-1024-bit-DH)
-    - Add variables in `group_vars/all`
-    - needs testing
-5. Test this guide from very beginning to very end.
+1. Make a workflow for adding a new user and client certificate "for a friend"
+1. Add an automatic updates tool. 
+1. Test this guide from very beginning to very end.
     - Beginning: Create a Digital Ocean Account
     - End: Install the ovpn cert and put the password in on all your devices
     - Very End: Maintaining your server
-6. Deploy to the world at large (reddit? digital ocean article?)
+1. Deploy to the world at large (reddit? digital ocean article?)
 
 
 #### Stouts.openvpn


### PR DESCRIPTION
I just made a new server and the server key is 2048 bits, which is in line with the [configuration setting](https://github.com/lazzarello/popup-openvpn/commit/f3bdf04b7799f5d648c0c692738be711fcd65391#diff-fc7cb0a7b647c6ff35b553a10d616c4bR12) in `group_vars/all`

I updated the documentation to reflect this state.

```
root@ip-172-31-17-171:/etc/openvpn/keys# ssh-keygen -l -f server.key
2048 SHA256:4zPUMx3m/G63KEd30CySCVmYF74WoXMFAskuLlJUoQ8 no comment (RSA)
```